### PR TITLE
Обновление ссылки на VoxelCore в README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # REMP
 
-**Re**translator **m**ulti**p**layer demo implementation for [VoxelCore](github.com/MihailRis/VoxelEngine-Cpp/).
+**Re**translator **m**ulti**p**layer demo implementation for [VoxelCore](https://github.com/MihailRis/voxelcore).
 
 **Status:** in-development
 


### PR DESCRIPTION
Ломанная ссылка: `https://github.com/MihailRis/remp/blob/master/github.com/MihailRis/VoxelEngine-Cpp`
Правильная ссылка: `https://github.com/MihailRis/voxelcore`